### PR TITLE
Tabs white background fix

### DIFF
--- a/infl-patternlab/source/css/style.scss
+++ b/infl-patternlab/source/css/style.scss
@@ -11,7 +11,22 @@ $path_to_proxima_nova_light_italic_font : url('../fonts/ProximaNova-LightIt.ttf'
 @import "bourbon";
 @import "neat";
 
-@import "infl-styles/all";
+@import "infl-styles/normalize";
+@import "infl-styles/theme";
+@import "infl-styles/fonts";
+@import "infl-styles/infl_base";
+@import "infl-styles/typography";
+@import "infl-styles/accordion";
+@import "infl-styles/alert";
+@import "infl-styles/icon";
+@import "infl-styles/button";
+@import "infl-styles/form";
+@import "infl-styles/help_tooltip";
+@import "infl-styles/toggle_switch";
+@import "infl-styles/loading";
+@import "infl-styles/modal_dialog";
+@import "infl-styles/tabs";
+
 
 //to force the styles to take affect in the pattern lab
 body {

--- a/infl-styles/_tabs.scss
+++ b/infl-styles/_tabs.scss
@@ -1,14 +1,16 @@
 .pt-tabs {
-  with: 100%;
+  width: 100%;
 
   .pt-tabs-menu {
     width: 100%;
-    border-bottom: 1px solid $light-grey;
     padding: 0px;
     margin-bottom: 0px;
+    overflow: hidden;
 
     .pt-tab {
-      display: inline-block;
+      float: left;
+      border-bottom: 1px solid $light-grey;
+      box-sizing: border-box;
       width: 150px;
       list-style-type: none;
       z-index: 3;
@@ -25,16 +27,22 @@
       }
 
       &.tab-open {
-        background-color:#fff;
         border-top: 3px solid $info-color;
-        border-bottom: 1px solid #fff;
-
+        border-bottom: none;
         a {
           border-right: 1px solid $light-grey;
           border-left: 1px solid $light-grey;
           position: relative;
           color: $info-color;
         }
+      }
+
+      &:last-child:after {
+        position:absolute;
+        left: 100%;
+        content: '';
+        width: 9999%;
+        border-bottom: 1px solid $light-grey;
       }
     }
   }


### PR DESCRIPTION
Previously, tabs required that they were placed on a white background or it did not render correctly. This changes how we render tabs so that it can be placed on any background.