### PR TITLE
Br/modal closing fixes

### DIFF
--- a/infl-components/modal_dialog.jsx
+++ b/infl-components/modal_dialog.jsx
@@ -20,25 +20,21 @@ var ModalDialog = React.createClass({
     lightbox : React.PropTypes.bool
   },
   getInitialState : function(){
-    if (this.props.isModalOpen) {
-      this._disableBodyScroll();
-    }
-    return {
-      isModalOpen : this.props.isModalOpen
-    };
+    return { isModalOpen : this.props.isModalOpen };
   },
   componentWillReceiveProps : function(newProps){
-    this.setState({
-      isModalOpen : newProps.isModalOpen
-    });
+    this.setState({ isModalOpen : newProps.isModalOpen });
   },
   componentDidUpdate: function(){
     if (this.state.isModalOpen) {
       this._disableBodyScroll();
     }
     else {
-      this._enableBodyScroll();
+      this._onClose();
     }
+  },
+  componentDidMount: function () {
+    if (this.props.isModalOpen) { this._disableBodyScroll(); }
   },
   componentWillUnmount: function () {
     this._onClose();

--- a/infl-components/modal_dialog.jsx
+++ b/infl-components/modal_dialog.jsx
@@ -40,6 +40,9 @@ var ModalDialog = React.createClass({
       this._enableBodyScroll();
     }
   },
+  componentWillUnmount: function () {
+    this._onClose();
+  },
   render : function(){
     return (
       <div id={this.props.id} className={"pt-modal-dialog  " + this._showModal() + " " + this._scrollingModalBody() + " " + this._lightbox()} onClick={this._closeDialog} ref="modalDialog">
@@ -55,9 +58,6 @@ var ModalDialog = React.createClass({
   },
   _scrollingModalBody : function(){
     return this.props.scrollingBody ? "scrolling-body" : "";
-  },
-  _disableBodyScroll : function(){
-    this._getBodyElement().style.overflow = "hidden";
   },
   _lightbox : function(){
     return this.props.lightbox ? "lightbox" : "";
@@ -82,11 +82,13 @@ var ModalDialog = React.createClass({
     this.props.onClose();
     this._enableBodyScroll();
   },
-  _enableBodyScroll : function(){
-    this._getBodyElement().style.overflow = "auto";
+
+  _disableBodyScroll : function () {
+    document.body.style.overflow = "hidden";
   },
-  _getBodyElement : function(){
-    return document.getElementsByTagName('body')[0];
+
+  _enableBodyScroll : function(){
+    document.body.style.overflow = "auto";
   }
 });
 

--- a/infl-components/spec/modal_dialog_spec.js
+++ b/infl-components/spec/modal_dialog_spec.js
@@ -5,7 +5,7 @@ var simulate  = ReactTestUtils.Simulate;
 var simulateNative = ReactTestUtils.SimulateNative;
 var _ = require('lodash');
 
-var ModalDailog = require("modal_dialog");
+var ModalDialog = require("modal_dialog");
 var ButtonGroup = require("button_group");
 
 var chai = require("chai");
@@ -46,20 +46,23 @@ describe('Modal Dialog Component', function() {
     _.defaults(defaultConfig, config);
 
     renderModalDialog(
-      <ModalDailog id={config.id} closeable={config.closeable} size={config.size} onClose={config.onClose} isModalOpen={config.isModalOpen} scrollingBody={config.scrollingBody} lightbox={config.lightbox}>
-        <ModalDailog.Header title="Modal Dialog Header Title" />
-        <ModalDailog.Body>
+      <ModalDialog id={config.id} closeable={config.closeable} size={config.size}
+        onClose={config.onClose} isModalOpen={config.isModalOpen}
+        scrollingBody={config.scrollingBody} lightbox={config.lightbox} >
+
+        <ModalDialog.Header title="Modal Dialog Header Title" />
+        <ModalDialog.Body>
             <p>This is the modal body. This is the modal body.</p>
             <p>This is the modal body. This is the modal body.</p>
             <p>This is the modal body. This is the modal body.</p>
-        </ModalDailog.Body>
-        <ModalDailog.Footer>
+        </ModalDialog.Body>
+        <ModalDialog.Footer>
             <ButtonGroup>
                 <button type="text">Cancel</button>
                 <button type="success">Save</button>
             </ButtonGroup>
-        </ModalDailog.Footer>
-      </ModalDailog>
+        </ModalDialog.Footer>
+      </ModalDialog>
     );
   }
 
@@ -79,19 +82,15 @@ describe('Modal Dialog Component', function() {
   });
 
   it('will disabled the scroll of the body when open', function () {
-    buildModalDialog({
-      isModalOpen : true
-    });
-    var bodyElement = document.getElementsByTagName('body')[0];
-    expect(bodyElement.style.overflow).to.equal("hidden");
+    buildModalDialog({ isModalOpen : true });
+
+    expect(document.body.style.overflow).to.equal("hidden");
   });
 
   xit('will enable the scroll of the body when closed', function () {
-    buildModalDialog({
-      isModalOpen : false
-    });
-    var bodyElement = document.getElementsByTagName('body')[0];
-    expect(bodyElement.style.overflow).to.equal("auto");
+    buildModalDialog({ isModalOpen : false });
+
+    expect(document.body.style.overflow).to.equal("auto");
   });
 
   describe('Closeable', function () {


### PR DESCRIPTION
1. unMounting the modal should run the "close" callbacks
2. on didUpdate, if the new props *hide* the modal, also run the "close" callbacks
3. refactored body scrolling to happen on didMount rather than getInitialState
4. `document.getElementsByTagName('body')[0]` can be shortened to `document.body` and is faster