### PR TITLE
HUB-305: checkbox not centered

### DIFF
--- a/infl-styles/_checkbox.scss
+++ b/infl-styles/_checkbox.scss
@@ -37,7 +37,6 @@
       &:before {
         @include ic-check();
         color: $dark-grey;
-        position: absolute;
         font-size: 12px;
       }
     }
@@ -48,7 +47,6 @@
       &:before {
         @include ic-minus();
         color: $dark-grey;
-        position: absolute;
         font-size: 12px;
       }
     }


### PR DESCRIPTION
Why:

Absolute positioning is not reliable with changing icons and dimensions. Rely on flex centering.

This change addresses the need by:

Removed some absolute positioning