### PR TITLE
PAT-198: Reduced asterisk size on required input

### DIFF
--- a/infl-styles/_form.scss
+++ b/infl-styles/_form.scss
@@ -74,10 +74,10 @@ textarea {
 
   .required-input {
     position: absolute;
-    top: 11px;
+    top: 9px;
     left: 2px;
     color: $error-color;
-    font-size: 15px;
+    font-size: 9px;
   }
 
   input {


### PR DESCRIPTION
Why:

The asterisk icon has increased in size due to syncing icon styles. The asterisk is too large for the form.

This change addresses the need by:

Reduce font size to bring it into better alignment.
Also, adjust vertical positioning to compensate.